### PR TITLE
updated duplicate scenario name checking and added tests

### DIFF
--- a/src/rules/no-dupe-scenario-names.js
+++ b/src/rules/no-dupe-scenario-names.js
@@ -9,13 +9,16 @@ function noDuplicateScenarioNames(feature, file) {
         let allScenarios = [];
         if (scenario.type === 'ScenarioOutline') {
           scenario.examples.forEach(function (example) {
-            example.tableBody.forEach(function (row) {
+            for (let row of example.tableBody) {
               let scenarioName = scenario.name;
               example.tableHeader.cells.forEach(function(header, index) {
                 scenarioName = scenarioName.replace(`<${header.value}>`, row.cells[index].value);
               });
               allScenarios.push(scenarioName);
-            });
+              if (scenarioName === scenario.name) {
+                break;
+              }
+            }
           });
         } else {
           allScenarios.push(scenario.name);

--- a/test/rules/no-dupe-scenario-names/DifferentScenarioOutline.feature
+++ b/test/rules/no-dupe-scenario-names/DifferentScenarioOutline.feature
@@ -13,3 +13,10 @@ Feature: Feature with different scenario outline
       | Scenario                  |
       | DifferentScenarioOutline3 |
       | DifferentScenarioOutline4 |
+
+  Scenario Outline: DifferentScenarioOutline5
+    Then this is a then step <step>
+    Examples:
+      | step |
+      | 1    |
+      | 2    |

--- a/test/rules/no-dupe-scenario-names/DifferentScenarioOutline.feature
+++ b/test/rules/no-dupe-scenario-names/DifferentScenarioOutline.feature
@@ -1,0 +1,15 @@
+Feature: Feature with different scenario outline
+
+  Scenario Outline: <Scenario>
+    Then this is a then step
+    Examples:
+      | Scenario                  |
+      | DifferentScenarioOutline1 |
+      | DifferentScenarioOutline2 |
+
+  Scenario Outline: <Scenario>
+    Then this is a then step
+    Examples:
+      | Scenario                  |
+      | DifferentScenarioOutline3 |
+      | DifferentScenarioOutline4 |

--- a/test/rules/no-dupe-scenario-names/DifferentScenarioOutlineAndScenarios.feature
+++ b/test/rules/no-dupe-scenario-names/DifferentScenarioOutlineAndScenarios.feature
@@ -14,8 +14,18 @@ Feature: Feature with different scenario outline
       | DifferentScenarioOutlineAndScenarios3 |
       | DifferentScenarioOutlineAndScenarios4 |
 
-  Scenario: DifferentScenarioOutlineAndScenarios5
-    Then this is a then step
+  Scenario Outline: DifferentScenarioOutlineAndScenarios5
+    Then this is a then step <step>
+    Examples:
+      | step |
+      | 1    |
+      | 2    |
 
   Scenario: DifferentScenarioOutlineAndScenarios6
+    Then this is a then step
+
+  Scenario: DifferentScenarioOutlineAndScenarios7
+    Then this is a then step
+
+  Scenario: DifferentScenarioOutlineAndScenarios8
     Then this is a then step

--- a/test/rules/no-dupe-scenario-names/DifferentScenarioOutlineAndScenarios.feature
+++ b/test/rules/no-dupe-scenario-names/DifferentScenarioOutlineAndScenarios.feature
@@ -1,0 +1,21 @@
+Feature: Feature with different scenario outline
+
+  Scenario Outline: <Scenario>
+    Then this is a then step
+    Examples:
+      | Scenario                              |
+      | DifferentScenarioOutlineAndScenarios1 |
+      | DifferentScenarioOutlineAndScenarios2 |
+
+  Scenario Outline: <Scenario>
+    Then this is a then step
+    Examples:
+      | Scenario                              |
+      | DifferentScenarioOutlineAndScenarios3 |
+      | DifferentScenarioOutlineAndScenarios4 |
+
+  Scenario: DifferentScenarioOutlineAndScenarios5
+    Then this is a then step
+
+  Scenario: DifferentScenarioOutlineAndScenarios6
+    Then this is a then step

--- a/test/rules/no-dupe-scenario-names/DifferentScenarios.feature
+++ b/test/rules/no-dupe-scenario-names/DifferentScenarios.feature
@@ -1,0 +1,7 @@
+Feature: Feature with different scenarios
+
+  Scenario: DifferentScenarios1
+    Then this is a then step
+
+  Scenario: DifferentScenarios2
+    Then this is a then step

--- a/test/rules/no-dupe-scenario-names/DuplicatedScenarioOutline.feature
+++ b/test/rules/no-dupe-scenario-names/DuplicatedScenarioOutline.feature
@@ -1,0 +1,15 @@
+Feature: Feature with duplicated scenario outline
+
+  Scenario Outline: <Scenario>
+    Then this is a then step
+    Examples:
+      | Scenario                   |
+      | DuplicatedScenarioOutline1 |
+      | DuplicatedScenarioOutline2 |
+
+  Scenario Outline: <Scenario>
+    Then this is a then step
+    Examples:
+      | Scenario                   |
+      | DuplicatedScenarioOutline3 |
+      | DuplicatedScenarioOutline2 |

--- a/test/rules/no-dupe-scenario-names/DuplicatedScenarioOutline.feature
+++ b/test/rules/no-dupe-scenario-names/DuplicatedScenarioOutline.feature
@@ -13,3 +13,10 @@ Feature: Feature with duplicated scenario outline
       | Scenario                   |
       | DuplicatedScenarioOutline3 |
       | DuplicatedScenarioOutline2 |
+
+  Scenario Outline: DuplicatedScenarioOutline1
+    Then this is a then step <step>
+    Examples:
+      | step |
+      | 1    |
+      | 2    |

--- a/test/rules/no-dupe-scenario-names/DuplicatedScenarioOutlineAndScenarios.feature
+++ b/test/rules/no-dupe-scenario-names/DuplicatedScenarioOutlineAndScenarios.feature
@@ -14,8 +14,18 @@ Feature: Feature with different scenario outline
       | DuplicatedScenarioOutlineAndScenarios3 |
       | DuplicatedScenarioOutlineAndScenarios4 |
 
+  Scenario Outline: DuplicatedScenarioOutlineAndScenarios5
+    Then this is a then step <step>
+    Examples:
+      | step |
+      | 1    |
+      | 2    |
+
   Scenario: DuplicatedScenarioOutlineAndScenarios1
     Then this is a then step
 
   Scenario: DuplicatedScenarioOutlineAndScenarios3
+    Then this is a then step
+
+  Scenario: DuplicatedScenarioOutlineAndScenarios5
     Then this is a then step

--- a/test/rules/no-dupe-scenario-names/DuplicatedScenarioOutlineAndScenarios.feature
+++ b/test/rules/no-dupe-scenario-names/DuplicatedScenarioOutlineAndScenarios.feature
@@ -1,0 +1,21 @@
+Feature: Feature with different scenario outline
+
+  Scenario Outline: <Scenario>
+    Then this is a then step
+    Examples:
+      | Scenario                               |
+      | DuplicatedScenarioOutlineAndScenarios1 |
+      | DuplicatedScenarioOutlineAndScenarios2 |
+
+  Scenario Outline: <Scenario>
+    Then this is a then step
+    Examples:
+      | Scenario                               |
+      | DuplicatedScenarioOutlineAndScenarios3 |
+      | DuplicatedScenarioOutlineAndScenarios4 |
+
+  Scenario: DuplicatedScenarioOutlineAndScenarios1
+    Then this is a then step
+
+  Scenario: DuplicatedScenarioOutlineAndScenarios3
+    Then this is a then step

--- a/test/rules/no-dupe-scenario-names/DuplicatedScenarios.feature
+++ b/test/rules/no-dupe-scenario-names/DuplicatedScenarios.feature
@@ -1,0 +1,7 @@
+Feature: Feature with same scenarios
+
+  Scenario: DuplicatedScenarios1
+    Then this is a then step
+
+  Scenario: DuplicatedScenarios1
+    Then this is a then step

--- a/test/rules/no-dupe-scenario-names/no-dupe-scenario-names.js
+++ b/test/rules/no-dupe-scenario-names/no-dupe-scenario-names.js
@@ -1,0 +1,43 @@
+var ruleTestBase = require('../rule-test-base');
+var rule = require('../../../src/rules/no-dupe-scenario-names');
+var runTest = ruleTestBase.createRuleTest(rule, 'Scenario name is already used in: no-dupe-scenario-names/<%= scenarioName %>.feature:<%= line %>');
+
+describe('No Duplicate Scenario Name Rule', function() {
+  it('doesn\'t raise errors when simple scenarios have different names', function() {
+    runTest('no-dupe-scenario-names/DifferentScenarios.feature', {}, []);
+  });
+
+  it('doesn\'t raise errors when scenario outlines have different names', function() {
+    runTest('no-dupe-scenario-names/DifferentScenarioOutline.feature', {}, []);
+  });
+
+  it('doesn\'t raise errors when simple scenarios and scenario outlines have different names', function() {
+    runTest('no-dupe-scenario-names/DifferentScenarioOutlineAndScenarios.feature', {}, []);
+  });
+
+  it('raise errors when simple scenarios have same names', function() {
+    runTest('no-dupe-scenario-names/DuplicatedScenarios.feature', {}, [{
+      messageElements: {scenarioName: 'DuplicatedScenarios', line: 3},
+      line: 6
+    }]);
+  });
+
+  it('raise errors when scenario outlines have same names', function() {
+    runTest('no-dupe-scenario-names/DuplicatedScenarioOutline.feature', {}, [{
+      messageElements: {scenarioName: 'DuplicatedScenarioOutline', line: 3},
+      line: 10
+    }]);
+  });
+
+  it('raise errors when simple scenarios and scenario outlines have same names', function() {
+    runTest('no-dupe-scenario-names/DuplicatedScenarioOutlineAndScenarios.feature', {}, [{
+      messageElements: {scenarioName: 'DuplicatedScenarioOutlineAndScenarios', line: 3},
+      line: 17
+    },
+    {
+      messageElements: {scenarioName: 'DuplicatedScenarioOutlineAndScenarios', line: 10},
+      line: 20
+    }]);
+  });
+
+});

--- a/test/rules/no-dupe-scenario-names/no-dupe-scenario-names.js
+++ b/test/rules/no-dupe-scenario-names/no-dupe-scenario-names.js
@@ -26,17 +26,25 @@ describe('No Duplicate Scenario Name Rule', function() {
     runTest('no-dupe-scenario-names/DuplicatedScenarioOutline.feature', {}, [{
       messageElements: {scenarioName: 'DuplicatedScenarioOutline', line: 3},
       line: 10
+    },
+    {
+      messageElements: {scenarioName: 'DuplicatedScenarioOutline', line: 3},
+      line: 17
     }]);
   });
 
   it('raise errors when simple scenarios and scenario outlines have same names', function() {
     runTest('no-dupe-scenario-names/DuplicatedScenarioOutlineAndScenarios.feature', {}, [{
       messageElements: {scenarioName: 'DuplicatedScenarioOutlineAndScenarios', line: 3},
-      line: 17
+      line: 24
     },
     {
       messageElements: {scenarioName: 'DuplicatedScenarioOutlineAndScenarios', line: 10},
-      line: 20
+      line: 27
+    },
+    {
+      messageElements: {scenarioName: 'DuplicatedScenarioOutlineAndScenarios', line: 17},
+      line: 30
     }]);
   });
 

--- a/test/rules/rule-test-base.js
+++ b/test/rules/rule-test-base.js
@@ -15,8 +15,13 @@ function createRuleTest(rule, messageTemplate) {
         line: error.line
       };
     });
-    var parsedFile = parser.parse(fs.readFileSync('test/rules/' + featureFile, 'utf8')).feature;
-    assert.sameDeepMembers(rule.run(parsedFile, undefined, configuration), expectedErrors);
+    var fileContent = fs.readFileSync('test/rules/' + featureFile, 'utf8');
+    var parsedFile = parser.parse(fileContent).feature;
+    var file = {
+      name: featureFile,
+      lines: fileContent.split(/\r\n|\r|\n/)
+    };
+    assert.sameDeepMembers(rule.run(parsedFile, file, configuration), expectedErrors);
   };
 }
 


### PR DESCRIPTION
Fixed issue when if we have parameter in scenario outline name, this parameter was ignored. Example:

Scenario Outline: \<Scenario\>
....
Examples:
| Scenario | Initial Status| Renewed Status|
| SF API auto-renew gift digital USA | Expired | Active |

....

Scenario Outline: \<Scenario\>
....
Examples:
| Scenario |
| BI API auto-renew gift digital USA |

When we checking scenarios on name equality, we got an error that these scenarios has same name(). Right now we are replacing variables in scenario name and comparing formatted names (SF API auto-renew gift digital USA and BI API auto-renew gift digital USA)